### PR TITLE
Add Lighthouse Audit as Github Action

### DIFF
--- a/.github/workflows/lighthouse-audit.yml
+++ b/.github/workflows/lighthouse-audit.yml
@@ -5,6 +5,18 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+    - name: Create comment
+      id: pr-comment
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          Generating a Lighthouse Report for [https://team-ocean-recipes.netlify.app/](https://team-ocean-recipes.netlify.app/)
+          .
+          .
+          .
     - name: Lighthouse Audit
       id: lighthouse-audit
       uses: foo-software/lighthouse-check-action@master
@@ -13,3 +25,16 @@ jobs:
         gitHubAccessToken: ${{ secrets.GITHUB_TOKEN }}
         prCommentEnabled: true
         device: 'desktop'
+    - name: Update a comment
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        comment-id: ${{steps.pr-comment.outputs.comment-id}}
+        body: |
+          Report finished!
+
+          ### Lighthouse Audit Results
+          - Accessibility Score: ${{ fromJson(steps.lighthouse-audit.outputs.lighthouseCheckResults).data[0].scores.accessibility }}
+          - Best Practices Score: ${{ fromJson(steps.lighthouse-audit.outputs.lighthouseCheckResults).data[0].scores.bestPractices }}
+          - Peformance Score: ${{ fromJson(steps.lighthouse-audit.outputs.lighthouseCheckResults).data[0].scores.performance }}
+          - Progressive Web App Score: ${{ fromJson(steps.lighthouse-audit.outputs.lighthouseCheckResults).data[0].scores.progressiveWebApp }}
+          - SEO Score: ${{ fromJson(steps.lighthouse-audit.outputs.lighthouseCheckResults).data[0].scores.seo }}

--- a/.github/workflows/lighthouse-audit.yml
+++ b/.github/workflows/lighthouse-audit.yml
@@ -1,0 +1,15 @@
+name: Lighthouse
+on: [pull_request]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Lighthouse Audit
+      id: lighthouse-audit
+      uses: foo-software/lighthouse-check-action@master
+      with:
+        urls: 'https://team-ocean-recipes.netlify.app/'
+        gitHubAccessToken: ${{ secrets.GITHUB_TOKEN }}
+        prCommentEnabled: true
+        device: 'desktop'

--- a/.github/workflows/lighthouse-audit.yml
+++ b/.github/workflows/lighthouse-audit.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         urls: 'https://team-ocean-recipes.netlify.app/'
         gitHubAccessToken: ${{ secrets.GITHUB_TOKEN }}
-        prCommentEnabled: true
+        prCommentEnabled: false # toggle this to use foo's default PR comment for audit results
         device: 'desktop'
     - name: Update a comment
       uses: peter-evans/create-or-update-comment@v1
@@ -33,6 +33,7 @@ jobs:
           Report finished!
 
           ### Lighthouse Audit Results
+          Note: Tests ran on desktop device.
           - Accessibility Score: ${{ fromJson(steps.lighthouse-audit.outputs.lighthouseCheckResults).data[0].scores.accessibility }}
           - Best Practices Score: ${{ fromJson(steps.lighthouse-audit.outputs.lighthouseCheckResults).data[0].scores.bestPractices }}
           - Peformance Score: ${{ fromJson(steps.lighthouse-audit.outputs.lighthouseCheckResults).data[0].scores.performance }}


### PR DESCRIPTION
PR's now trigger a github action that audits the web app with lighthouse. The audit results are published as a comment on the PR.